### PR TITLE
Add sequence fuzzer

### DIFF
--- a/src/Fuzz/Extra.elm
+++ b/src/Fuzz/Extra.elm
@@ -1,8 +1,8 @@
-module Fuzz.Extra exposing (eitherOr, uniformOrCrash, stringMaxLength, union)
+module Fuzz.Extra exposing (eitherOr, uniformOrCrash, stringMaxLength, union, sequence)
 
 {-| Extends `Fuzz` with more `Fuzzer`s.
 
-@docs eitherOr, uniformOrCrash, stringMaxLength
+@docs eitherOr, uniformOrCrash, stringMaxLength, sequence
 
 ## Deprecated
 
@@ -68,6 +68,20 @@ stringMaxLength high =
             |> Random.andThen (lengthString charGenerator)
         )
         Shrink.string
+
+
+{-| Sequence a list of fuzzers into a fuzzer of a list.
+-}
+sequence : List (Fuzzer a) -> Fuzzer (List a)
+sequence fuzzers =
+    List.foldl
+        (\fuzzer listFuzzer ->
+            Fuzz.constant (::)
+                |> Fuzz.andMap fuzzer
+                |> Fuzz.andMap listFuzzer
+        )
+        (Fuzz.constant [])
+        fuzzers
 
 
 {-| Create a fuzzer for a union type.


### PR DESCRIPTION
Hey there! Thanks for your work on this library.

This PR contains a suggestion for an addition fuzz helper, one which allows you to take a list of fuzzers and turn them into a fuzzer of a list. One application for this is to create a fuzzy subset of a list, like so:

```elm
subset : List a -> Fuzzer (List a)
subset xs =
  List.map (Fuzz.constant >> Fuzz.maybe) xs
    |> Fuzz.Extra.sequence
    |> Fuzz.map List.Extra.values
```

Is this the kind of thing you feel has a place in this library?