### PR TITLE
Remove unused dependency elm-community/lazy-list

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -13,7 +13,6 @@
     ],
     "dependencies": {
         "elm-community/elm-test": "4.0.0 <= v < 5.0.0",
-        "elm-community/lazy-list": "1.0.0 <= v < 2.0.0",
         "elm-community/shrink": "2.0.0 <= v < 3.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "mgold/elm-random-pcg": "5.0.0 <= v < 6.0.0"


### PR DESCRIPTION
elm-test-extra is depending on elm-community/lazy-list, but isn't actually using that package in the code (only in the tests, where I left it alone).

This was causing an issue for me. The new elm-test depends on eeue65/lazy-list instead, which has the same API as the elm-community/lazy-list. If you try to pull in both at the same time you might run into cryptic elm errors.