### PR TITLE
Replace elm-community/shrink -> eeue65/elm-shrink

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -13,7 +13,7 @@
     ],
     "dependencies": {
         "elm-community/elm-test": "4.0.0 <= v < 5.0.0",
-        "elm-community/shrink": "2.0.0 <= v < 3.0.0",
+        "eeue56/elm-shrink": "1.0.0 <= v < 2.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "mgold/elm-random-pcg": "5.0.0 <= v < 6.0.0"
     },

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -12,7 +12,7 @@
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-community/elm-test": "4.0.0 <= v < 5.0.0",
         "elm-community/lazy-list": "1.0.0 <= v < 2.0.0",
-        "elm-community/shrink": "2.0.0 <= v < 3.0.0",
+        "eeue56/elm-shrink": "1.0.0 <= v < 2.0.0",
         "mgold/elm-random-pcg": "5.0.0 <= v < 6.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"


### PR DESCRIPTION
Hey @ktonon, looks like I missed a dependency in my last PR. `shrink` also needs to be updated to use the eeue65 version, or we're still getting elm-community/lazy-list via it.

Sorry for the separate PR's!

> elm-community/shrink in turn pulls in elm-community/lazy-list. The new
> version of elm-test is using the eeue65 packages as well. To be able to
> work together with them elm-test-extra also needs to use these packages.