### PR TITLE
Add 'just' and 'exactly' expectations

### DIFF
--- a/src/Expect/Extra.elm
+++ b/src/Expect/Extra.elm
@@ -1,6 +1,8 @@
 module Expect.Extra exposing
     ( match, MatchPattern, stringPattern, regexPattern
     , contain, member
+    , just
+    , exactly
     )
 
 {-| Extends `Expect` with more `Expectation`s.
@@ -14,6 +16,16 @@ module Expect.Extra exposing
 ## Lists
 
 @docs contain, member
+
+
+## Maybes
+
+@docs just
+
+
+## Floats
+
+@docs exactly
 
 -}
 
@@ -102,3 +114,44 @@ Reads better with bdd style tests.
 contain : a -> (a -> String) -> List a -> Expectation
 contain value toString =
     member toString value
+
+
+{-| Passes if the actual value is a `Just` and the contained value passes the
+given expectation function.
+
+    -- Passes:
+    just (Expect.equal "foo") (Just "foo")
+
+    -- Fails:
+    just (Expect.equal "foo") (Just "bar")
+
+    -- Fails:
+    just (Expect.equal "foo") Nothing
+
+-}
+just : (actual -> Expectation) -> Maybe actual -> Expectation
+just expectation actualMaybe =
+    case actualMaybe of
+        Just actualValue ->
+            expectation actualValue
+
+        Nothing ->
+            Expect.fail "Expected a Just but got Nothing"
+
+
+{-| Passes if the actual value is _exactly_ equal to the expected value.
+
+Note that this is usually only desirable in low-level numeric code and most
+tests should use [`Expect.within`](https://package.elm-lang.org/packages/elm-explorations/test/latest/Expect#floating-point-comparisons)
+instead.
+
+    -- Passes:
+    exactly 1.5 1.5
+
+    -- Fails:
+    exactly 1.5 1.50000000001
+
+-}
+exactly : Float -> Float -> Expectation
+exactly expected actual =
+    Expect.within (Expect.Absolute 0.0) expected actual

--- a/tests/ExpectTests.elm
+++ b/tests/ExpectTests.elm
@@ -79,4 +79,33 @@ all =
                         (Expect.fail "Expected:\n  [1, 2, 3]\nto contain:\n  4")
                         (member Debug.toString 4 [ 1, 2, 3 ])
             ]
+        , describe "just" <|
+            [ test "matching Just" <|
+                \_ ->
+                    Expect.equal
+                        Expect.pass
+                        (just (Expect.equal "foo") (Just "foo"))
+            , test "non-matching Just" <|
+                \_ ->
+                    Expect.equal
+                        (Expect.equal "foo" "bar")
+                        (just (Expect.equal "foo") (Just "bar"))
+            , test "Nothing" <|
+                \_ ->
+                    Expect.equal
+                        (Expect.fail "Expected a Just but got Nothing")
+                        (just (Expect.equal "foo") Nothing)
+            ]
+        , describe "exactly" <|
+            [ test "equal" <|
+                \_ ->
+                    Expect.equal
+                        Expect.pass
+                        (exactly 1.0 1.0)
+            , test "not equal" <|
+                \_ ->
+                    Expect.equal
+                        (Expect.within (Expect.Absolute 0) 1.0 1.0001)
+                        (exactly 1.0 1.0001)
+            ]
         ]


### PR DESCRIPTION
These are a couple of generic expectations that I've found useful when testing [`elm-geometry`](https://package.elm-lang.org/packages/ianmackenzie/elm-geometry/latest/) code. I'm working on publishing a bunch of fuzzers and expectations for `elm-geometry` types in a new `elm-geometry-test` package, but these two functions seemed general-purpose enough to be in an `elm-test-extra` package.

I tried to match the style of the existing docs/tests but I'm happy to tweak if desired.