### PR TITLE
Fuzz.Extra.sequence now respects the order of its input fuzzers

### DIFF
--- a/src/Fuzz/Extra.elm
+++ b/src/Fuzz/Extra.elm
@@ -74,7 +74,7 @@ stringMaxLength high =
 -}
 sequence : List (Fuzzer a) -> Fuzzer (List a)
 sequence fuzzers =
-    List.foldl
+    List.foldr
         (\fuzzer listFuzzer ->
             Fuzz.constant (::)
                 |> Fuzz.andMap fuzzer

--- a/tests/FuzzTests.elm
+++ b/tests/FuzzTests.elm
@@ -16,4 +16,9 @@ all =
                 \w ->
                     Expect.lessThan 11 (w |> String.length)
             ]
+        , describe "sequence"
+            [ fuzz (Fuzz.Extra.sequence <| List.map Fuzz.constant [ "::first::", "::second::", "::third::" ]) "the sequence of fuzzers respects the sequence of inputs" <|
+                \items ->
+                    Expect.equal [ "::first::", "::second::", "::third::" ] items
+            ]
         ]


### PR DESCRIPTION
I know that this is a breaking change, but it seemed strange to me that `sequence` would turn the fuzzers `[a, b, c]` into a fuzzer that produces lists like `[c, b, a]`. Accordingly, I've added a simple test to illustrate the behavior I was expected and have "fixed" the function.

I can understand if you'd rather not introduce a breaking change abruptly like this I'm open to alternatives to suggesting how to introduce this change into the library. At a minimum, if `sequence` is going to retain its current behavior, then I would recommend emphasizing that in its documentation.